### PR TITLE
Fix FizzBuzz's termination condition

### DIFF
--- a/exercises/generator/solution/solution.js
+++ b/exercises/generator/solution/solution.js
@@ -1,7 +1,7 @@
 const max = process.argv[2];
 let FizzBuzz = function* (){
   let num = 1;
-  while (num < max) {
+  while (num <= max) {
     let value = num;
     num++;
     if (value % 15 === 0) {

--- a/exercises/iterator_for_of/solution/solution.js
+++ b/exercises/iterator_for_of/solution/solution.js
@@ -12,8 +12,8 @@ let FizzBuzz = {
         } else if (value % 5 === 0) {
           value = 'Buzz';
         }
-        num++;
         if (num <= max)  return { done: false, value: value };
+        num++;
         return { done: true };
       }
     }


### PR DESCRIPTION
Given 3 as `max` argument, the current solution prints only:

```
1
2
```

This PR fixes it to print:

```
1
2
Fizz
```