### PR TITLE
Rename some variables in example

### DIFF
--- a/exercises/generator/problem.ko.md
+++ b/exercises/generator/problem.ko.md
@@ -4,12 +4,12 @@ generator를 사용한 fibonacci는 다음과 같습니다.
 
 ```javascript
 let fibonacci = function*(){
-  let pre = 0, cur = 1;
-  while (pre < 1000) {
+  let currentValue = 0, nextValue = 1;
+  while (currentValue < 1000) {
     // 여기서 destructuring으로 값을 스왑함
-    [pre, cur] = [cur, pre + cur];
+    [currentValue, nextValue] = [nextValue, currentValue + nextValue];
     // yield로 값을 반환
-    yield pre;
+    yield currentValue;
   }
 }();
 

--- a/exercises/generator/problem.md
+++ b/exercises/generator/problem.md
@@ -4,12 +4,12 @@ generatorを使った時のfibonacciは以下のようになります。
 
 ```javascript
 let fibonacci = function*(){
-  let pre = 0, cur = 1;
-  while (pre < 1000) {
+  let currentValue = 0, nextValue = 1;
+  while (currentValue < 1000) {
     // ここでdestructuringで値をswapさせる。
-    [pre, cur] = [cur, pre + cur];
+    [currentValue, nextValue] = [nextValue, currentValue + nextValue];
     // yieldで値を返す
-    yield pre;
+    yield currentValue;
   }
 }();
 

--- a/exercises/iterator_for_of/problem.ko.md
+++ b/exercises/iterator_for_of/problem.ko.md
@@ -19,14 +19,14 @@ Iterable한 것을 만들려면, `Symbol.Iterator`를 사용하세요. `Symbol.I
 var fibonacci = {
   // Symbol.iterator를 가지는 메소드를 가지는 객체
   [Symbol.iterator]() {
-    let pre = 0, cur = 1;
+    let currentValue = 0, nextValue = 1;
     // iterator 객체는 next 메소드를 가진 객체를 반환
     return {
       next() {
         // next 안에서 반환 값(value)과 다음에 끝나는지 나타내는 속성(done)을 반환
-        [pre, cur] = [cur, pre + cur];
-        if (pre < 1000)  return { done: false, value: pre };
-        return { done: true };
+        if (nextValue > 1000) return { done: true };
+        [currentValue, nextValue] = [nextValue, currentValue + nextValue];
+        return { done: false, value: currentValue };
       }
     }
   }

--- a/exercises/iterator_for_of/problem.md
+++ b/exercises/iterator_for_of/problem.md
@@ -19,14 +19,14 @@ Iterable なものを作るには、 `Symbol.Iterator` を使います。 `Symbo
 var fibonacci = {
   // Symbol.iteratorを持つメソッドを持つオブジェクトにする
   [Symbol.iterator]() {
-    let pre = 0, cur = 1;
+    let currentValue = 0, nextValue = 1;
     // iteratorオブジェクトは nextメソッドを持つオブジェクトを返す
     return {
       next() {
         // nextの中では返す値(value)と次で終わりかどうかを示すプロパティ(done)を返す
-        [pre, cur] = [cur, pre + cur];
-        if (pre < 1000)  return { done: false, value: pre };
-        return { done: true };
+        if (nextValue > 1000) return { done: true };
+        [currentValue, nextValue] = [nextValue, currentValue + nextValue];
+        return { done: false, value: currentValue };
       }
     }
   }


### PR DESCRIPTION
I thought, if I want return or yield something, It should be current one.