### PR TITLE
Typo fix and allow space or comma-separated input into problem twelve.

### DIFF
--- a/exercises/block_scope/problem.md
+++ b/exercises/block_scope/problem.md
@@ -29,7 +29,7 @@ Modify this file by choosing either `var`, `let` or `const` to make the code beh
 
 ```javascript
 'use strict';
-// This variable `a` should be accessable outside of the block scope.
+// This variable `a` should be accessible outside of the block scope.
 var|let|const a = 5;
 
 // This variable `b` should not be reassignable.

--- a/exercises/rest_and_spread/problem.md
+++ b/exercises/rest_and_spread/problem.md
@@ -30,8 +30,15 @@ console.log(sum(...array)); // 10
 Calculate the average of all the numbers passed in using command line arguments using the `...` syntax.
 
 ```javascript
-var args = process.argv[2].split(",");
-args = args.map((arg)=> +arg);
+var rawArgs = process.argv.slice(2);
+var args = [];
+
+rawArgs.forEach(val => {
+  let commaSep = val.split(',');
+  commaSep.forEach(val => {
+    if(val !== '') args.push(+val);
+  });
+});
 
 // write a function called `avg` here that calculates the average.
 

--- a/exercises/rest_and_spread/solution/solution.js
+++ b/exercises/rest_and_spread/solution/solution.js
@@ -1,10 +1,15 @@
-var args = process.argv[2].split(",");
-args = args.map((arg)=> +arg);
+var rawArgs = process.argv.slice(2);
+var args = [];
 
-var avg = function(...args){
-  let sum = args.reduce( (sum, n) => sum + n );
-  return sum/args.length;
-};
+rawArgs.forEach(val => {
+  let commaSep = val.split(',');
+  commaSep.forEach(val => {
+    if(val !== '') args.push(+val);
+  });
+});
+
+function avg(...args){
+  return args.reduce((a, b)=>a+b)/args.length;
+}
 
 console.log(avg(...args));
-


### PR DESCRIPTION
Fixed a typo and allow command-line input to problem twelve (rest and spread) to accept either comma-separated values or space-separated values (the latter seems more natural imo).

so:
 `babel-node twelve.js 2,3,4` => `3`
`babel-node twelve.js 2 3 4` => `3`
`babel-node tweleve.js 2, 3   , 4` => `3`