### PR TITLE
Removing useless `var`

### DIFF
--- a/exercises/destructure/problem.es.md
+++ b/exercises/destructure/problem.es.md
@@ -18,7 +18,7 @@ var foo = 123;
 var bar = 456;
 
 // swapping of the value
-var [bar, foo] = [foo, bar];
+[bar, foo] = [foo, bar];
 ```
 Podemos incluso acceder a elementos que son hijos de un Array.
 

--- a/exercises/destructure/problem.ja.md
+++ b/exercises/destructure/problem.ja.md
@@ -19,7 +19,7 @@ var hoge = 123;
 var fuga = 456;
 
 // 値をswapする
-var [fuga, hoge] = [hoge, fuga];
+[fuga, hoge] = [hoge, fuga];
 ```
 
 これだけです、配列に２つの値を入れて左辺で交換するだけで実現できます。

--- a/exercises/destructure/problem.ko.md
+++ b/exercises/destructure/problem.ko.md
@@ -19,7 +19,7 @@ var hoge = 123;
 var fuga = 456;
 
 // 값을 스왑
-var [fuga, hoge] = [hoge, fuga];
+[fuga, hoge] = [hoge, fuga];
 ```
 
 이게 끝입니다. 배열에 2개의 값을 넣어 왼쪽의 변수를 교환하는 것만으로 구현 가능합니다.

--- a/exercises/destructure/problem.md
+++ b/exercises/destructure/problem.md
@@ -19,7 +19,7 @@ var foo = 123;
 var bar = 456;
 
 // swapping of the value
-var [bar, foo] = [foo, bar];
+[bar, foo] = [foo, bar];
 ```
 
 It is even possible to access elements that are children of the array.


### PR DESCRIPTION
I think the `var` is not required here, since both variables already exist.