### PR TITLE
Convert to ES6 module system

### DIFF
--- a/exercises/arrow_function/exercise.js
+++ b/exercises/arrow_function/exercise.js
@@ -1,17 +1,18 @@
 "use strict";
 
-var exercise = require('workshopper-exercise')();
-var filecheck = require('workshopper-exercise/filecheck');
-var execute = require('workshopper-exercise/execute');
-var comparestdout = require('workshopper-exercise/comparestdout');
-var babelProcessor = require('../babel-processor');
+import exercise       from 'workshopper-exercise';
+import filecheck      from 'workshopper-exercise/filecheck';
+import execute        from 'workshopper-exercise/execute';
+import comparestdout  from 'workshopper-exercise/comparestdout';
+import babelProcessor from '../babel-processor';
 
-module.exports = comparestdout(execute(babelProcessor(filecheck(exercise))));
+var obj = comparestdout(execute(babelProcessor(filecheck(exercise()))));
+
 var names = [
   "Hello", "Babel", "Arrow", "Function", "Sebastian", "Mckenzie", "Yosuke"
 ];
 
-module.exports.addSetup(function(mode, cb) {
+obj.addSetup(function(mode, cb) {
   // Fisher-Yates
   var i = names.length;
   while(i) {
@@ -25,3 +26,4 @@ module.exports.addSetup(function(mode, cb) {
   process.nextTick(cb);
 });
 
+export default obj;

--- a/exercises/babel-processor.js
+++ b/exercises/babel-processor.js
@@ -1,14 +1,13 @@
-"use strict";
-var babel = require("babel-core");
-var fs = require("fs");
-var q = require("q");
-var path = require("path");
-var os = require("os");
-var rimraf = require("rimraf");
+import {transform} from "babel-core";
+import fs     from "fs";
+import q      from "q";
+import path   from "path";
+import os     from "os";
+import rimraf from "rimraf";
 
 var tmpDir = path.resolve(os.tmpDir(), "_babel_" + process.pid);
 
-module.exports = function (exercise) {
+export default function (exercise) {
     exercise.addProcessor(processor);
     exercise.addCleanup(cleanup);
 
@@ -20,8 +19,8 @@ function processor(mode, callback) {
 
     q.nfcall(fs.mkdir, tmpDir).then(function () {
       return q.nfcall(
-        fs.symlink, 
-        path.resolve(__dirname + '/../node_modules'), 
+        fs.symlink,
+        path.resolve(__dirname + '/../node_modules'),
         tmpDir + '/node_modules');
     })
     .then(function(){
@@ -89,7 +88,7 @@ function writeFile(filename, contents) {
 }
 
 var transpile = q.fbind(function (contents, filename) {
-    var transpiled = babel.transform(contents, {
+    var transpiled = transform(contents, {
         filename: filename,
         modules: "common",
         optional: ["runtime"]

--- a/exercises/babel_setup/exercise.js
+++ b/exercises/babel_setup/exercise.js
@@ -1,17 +1,19 @@
 "use strict";
 
-var exercise = require('workshopper-exercise')();
-var filecheck = require('workshopper-exercise/filecheck');
-var execute = require('workshopper-exercise/execute');
-var comparestdout = require('workshopper-exercise/comparestdout');
-var babelProcessor = require('../babel-processor');
+import exercise       from 'workshopper-exercise';
+import filecheck      from 'workshopper-exercise/filecheck';
+import execute        from 'workshopper-exercise/execute';
+import comparestdout  from 'workshopper-exercise/comparestdout';
+import babelProcessor from '../babel-processor';
 
-module.exports = comparestdout(execute(babelProcessor(filecheck(exercise))));
+var obj = comparestdout(execute(babelProcessor(filecheck(exercise()))));
 
 var names = ['ES6', 'Babel', '6to5', 'transpiler', 'ES2015'];
-module.exports.addSetup(function(mode, cb) {
+obj.addSetup(function(mode, cb) {
   var name = names[Math.floor(Math.random() * names.length)];
   this.requiredString = ['`', '$'];
   this.submissionArgs = this.solutionArgs = [name];
   process.nextTick(cb);
 });
+
+export default obj;

--- a/exercises/block_scope/exercise.js
+++ b/exercises/block_scope/exercise.js
@@ -1,17 +1,19 @@
 "use strict";
 
-var exercise = require('workshopper-exercise')();
-var filecheck = require('workshopper-exercise/filecheck');
-var execute = require('workshopper-exercise/execute');
-var comparestdout = require('workshopper-exercise/comparestdout');
-var babelProcessor = require('../babel-processor');
+import exercise       from 'workshopper-exercise';
+import filecheck      from 'workshopper-exercise/filecheck';
+import execute        from 'workshopper-exercise/execute';
+import comparestdout  from 'workshopper-exercise/comparestdout';
+import babelProcessor from '../babel-processor';
 
-module.exports = comparestdout(execute(babelProcessor(filecheck(exercise))));
+var obj = comparestdout(execute(babelProcessor(filecheck(exercise()))));
 
-module.exports.addSetup(function(mode, cb) {
-  var x = Math.floor(Math.random() * 100); 
-  var y = Math.floor(Math.random() * 100); 
+obj.addSetup(function(mode, cb) {
+  var x = Math.floor(Math.random() * 100);
+  var y = Math.floor(Math.random() * 100);
   this.requiredString = ['let', 'const'];
   this.submissionArgs = this.solutionArgs = [x, y];
   process.nextTick(cb);
 });
+
+export default obj;

--- a/exercises/class/exercise.js
+++ b/exercises/class/exercise.js
@@ -1,17 +1,19 @@
 "use strict";
 
-var exercise = require('workshopper-exercise')();
-var filecheck = require('workshopper-exercise/filecheck');
-var execute = require('workshopper-exercise/execute');
-var comparestdout = require('workshopper-exercise/comparestdout');
-var babelProcessor = require('../babel-processor');
+import exercise       from 'workshopper-exercise';
+import filecheck      from 'workshopper-exercise/filecheck';
+import execute        from 'workshopper-exercise/execute';
+import comparestdout  from 'workshopper-exercise/comparestdout';
+import babelProcessor from '../babel-processor';
 
-module.exports = comparestdout(execute(babelProcessor(filecheck(exercise))));
+var obj = comparestdout(execute(babelProcessor(filecheck(exercise()))));
 
-module.exports.addSetup(function(mode, cb) {
-  var x = Math.floor(Math.random() * 100); 
-  var y = Math.floor(Math.random() * 100); 
+obj.addSetup(function(mode, cb) {
+  var x = Math.floor(Math.random() * 100);
+  var y = Math.floor(Math.random() * 100);
   this.requiredString = ['class'];
   this.submissionArgs = this.solutionArgs = [x, y];
   process.nextTick(cb);
 });
+
+export default obj;

--- a/exercises/class_extend/exercise.js
+++ b/exercises/class_extend/exercise.js
@@ -1,19 +1,22 @@
 "use strict";
 
-var exercise = require('workshopper-exercise')();
-var filecheck = require('workshopper-exercise/filecheck');
-var execute = require('workshopper-exercise/execute');
-var comparestdout = require('workshopper-exercise/comparestdout');
-var babelProcessor = require('../babel-processor');
+import exercise       from 'workshopper-exercise';
+import filecheck      from 'workshopper-exercise/filecheck';
+import execute        from 'workshopper-exercise/execute';
+import comparestdout  from 'workshopper-exercise/comparestdout';
+import babelProcessor from '../babel-processor';
 
-module.exports = comparestdout(execute(babelProcessor(filecheck(exercise))));
+var obj = comparestdout(execute(babelProcessor(filecheck(exercise()))));
+
 var names = ['alice', 'bob', 'charlie', 'dave', 'eva'];
 
-module.exports.addSetup(function(mode, cb) {
-  var x = Math.floor(Math.random() * 100); 
-  var y = Math.floor(Math.random() * 100); 
+obj.addSetup(function(mode, cb) {
+  var x = Math.floor(Math.random() * 100);
+  var y = Math.floor(Math.random() * 100);
   var name = names[Math.floor(Math.random() * names.length)];
   this.requiredString = ['class', 'extends'];
   this.submissionArgs = this.solutionArgs = [x, y, name];
   process.nextTick(cb);
 });
+
+export default obj;

--- a/exercises/computed_property/exercise.js
+++ b/exercises/computed_property/exercise.js
@@ -1,16 +1,18 @@
 "use strict";
 
-var exercise = require('workshopper-exercise')();
-var filecheck = require('workshopper-exercise/filecheck');
-var execute = require('workshopper-exercise/execute');
-var comparestdout = require('workshopper-exercise/comparestdout');
-var babelProcessor = require('../babel-processor');
+import exercise       from 'workshopper-exercise';
+import filecheck      from 'workshopper-exercise/filecheck';
+import execute        from 'workshopper-exercise/execute';
+import comparestdout  from 'workshopper-exercise/comparestdout';
+import babelProcessor from '../babel-processor';
 
-module.exports = comparestdout(execute(babelProcessor(filecheck(exercise))));
+var obj = comparestdout(execute(babelProcessor(filecheck(exercise()))));
 
-module.exports.addSetup(function(mode, cb) {
-  var x = Math.floor(Math.random() * 100); 
-  var y = Math.floor(Math.random() * 100); 
+obj.addSetup(function(mode, cb) {
+  var x = Math.floor(Math.random() * 100);
+  var y = Math.floor(Math.random() * 100);
   this.submissionArgs = this.solutionArgs = [x, y];
   process.nextTick(cb);
 });
+
+export default obj;

--- a/exercises/destructure/exercise.js
+++ b/exercises/destructure/exercise.js
@@ -1,17 +1,20 @@
 "use strict";
 
-var exercise = require('workshopper-exercise')();
-var filecheck = require('workshopper-exercise/filecheck');
-var execute = require('workshopper-exercise/execute');
-var comparestdout = require('workshopper-exercise/comparestdout');
-var babelProcessor = require('../babel-processor');
+import exercise       from 'workshopper-exercise';
+import filecheck      from 'workshopper-exercise/filecheck';
+import execute        from 'workshopper-exercise/execute';
+import comparestdout  from 'workshopper-exercise/comparestdout';
+import babelProcessor from '../babel-processor';
 
-module.exports = comparestdout(execute(babelProcessor(filecheck(exercise))));
+var obj = comparestdout(execute(babelProcessor(filecheck(exercise()))));
 
 var names = ['Furukawa', 'Nakajima', 'Kuwahara', 'Sora', 'Ishikawa'];
-module.exports.addSetup(function(mode, cb) {
+
+obj.addSetup(function(mode, cb) {
   var name = names[Math.floor(Math.random() * names.length)];
   var day = Math.floor(Math.random() * 31);
   this.submissionArgs = this.solutionArgs = [name, day];
   process.nextTick(cb);
 });
+
+export default obj;

--- a/exercises/generator/exercise.js
+++ b/exercises/generator/exercise.js
@@ -1,20 +1,22 @@
 "use strict";
 
-var fs = require('fs');
-var path = require('path');
-var os = require("os");
+import fs             from 'fs';
+import path           from 'path';
+import os             from 'os';
 
-var exercise = require('workshopper-exercise')();
-var filecheck = require('workshopper-exercise/filecheck');
-var execute = require('workshopper-exercise/execute');
-var comparestdout = require('workshopper-exercise/comparestdout');
-var babelProcessor = require('../babel-processor');
+import exercise       from 'workshopper-exercise';
+import filecheck      from 'workshopper-exercise/filecheck';
+import execute        from 'workshopper-exercise/execute';
+import comparestdout  from 'workshopper-exercise/comparestdout';
+import babelProcessor from '../babel-processor';
 
-module.exports = comparestdout(execute(babelProcessor(filecheck(exercise))));
+var obj = comparestdout(execute(babelProcessor(filecheck(exercise()))));
 
-module.exports.addSetup(function(mode, cb) {
-  var x = Math.floor(Math.random() * 100); 
+obj.addSetup(function(mode, cb) {
+  var x = Math.floor(Math.random() * 100);
   this.requiredString = ['yield'];
   this.submissionArgs = this.solutionArgs = [x];
   process.nextTick(cb);
 });
+
+export default obj;

--- a/exercises/iterator_for_of/exercise.js
+++ b/exercises/iterator_for_of/exercise.js
@@ -1,20 +1,22 @@
 "use strict";
 
-var fs = require('fs');
-var path = require('path');
-var os = require("os");
+import fs             from 'fs';
+import path           from 'path';
+import os             from 'os';
 
-var exercise = require('workshopper-exercise')();
-var filecheck = require('workshopper-exercise/filecheck');
-var execute = require('workshopper-exercise/execute');
-var comparestdout = require('workshopper-exercise/comparestdout');
-var babelProcessor = require('../babel-processor');
+import exercise       from 'workshopper-exercise';
+import filecheck      from 'workshopper-exercise/filecheck';
+import execute        from 'workshopper-exercise/execute';
+import comparestdout  from 'workshopper-exercise/comparestdout';
+import babelProcessor from '../babel-processor';
 
-module.exports = comparestdout(execute(babelProcessor(filecheck(exercise))));
+var obj = comparestdout(execute(babelProcessor(filecheck(exercise()))));
 
-module.exports.addSetup(function(mode, cb) {
-  var x = Math.floor(Math.random() * 100); 
+obj.addSetup(function(mode, cb) {
+  var x = Math.floor(Math.random() * 100);
   this.requiredString = ['Symbol.iterator'];
   this.submissionArgs = this.solutionArgs = [x];
   process.nextTick(cb);
 });
+
+export default obj;

--- a/exercises/modules_default_export/exercise.js
+++ b/exercises/modules_default_export/exercise.js
@@ -1,23 +1,25 @@
 "use strict";
 
-var exercise = require('workshopper-exercise')();
-var filecheck = require('workshopper-exercise/filecheck');
-var execute = require('workshopper-exercise/execute');
-var comparestdout = require('workshopper-exercise/comparestdout');
-var babelProcessor = require('../babel-processor');
+import exercise       from 'workshopper-exercise';
+import filecheck      from 'workshopper-exercise/filecheck';
+import execute        from 'workshopper-exercise/execute';
+import comparestdout  from 'workshopper-exercise/comparestdout';
+import babelProcessor from '../babel-processor';
 
-module.exports = comparestdout(execute(babelProcessor(filecheck(exercise))));
+var obj = comparestdout(execute(babelProcessor(filecheck(exercise()))));
 
-module.exports.addSetup(function(mode, cb) {
+obj.addSetup(function(mode, cb) {
   if (process.argv.length !== 5) {
     console.error("USAGE: tower-of-babel run|verify <executeFile> <importFile>");
     throw new Error("invalid arguments");
   }
   this.submissionImportFile = process.argv[4];
   this.requireImportString = ['export', 'default'];
-  var x = Math.floor(Math.random() * 100); 
-  var y = Math.floor(Math.random() * 100); 
+  var x = Math.floor(Math.random() * 100);
+  var y = Math.floor(Math.random() * 100);
   this.submissionArgs = this.solutionArgs = [x, y];
   this.requiredString = ['import'];
   process.nextTick(cb);
 });
+
+export default obj;

--- a/exercises/modules_with_name/exercise.js
+++ b/exercises/modules_with_name/exercise.js
@@ -1,23 +1,25 @@
 "use strict";
 
-var exercise = require('workshopper-exercise')();
-var filecheck = require('workshopper-exercise/filecheck');
-var execute = require('workshopper-exercise/execute');
-var comparestdout = require('workshopper-exercise/comparestdout');
-var babelProcessor = require('../babel-processor');
+import exercise       from 'workshopper-exercise';
+import filecheck      from 'workshopper-exercise/filecheck';
+import execute        from 'workshopper-exercise/execute';
+import comparestdout  from 'workshopper-exercise/comparestdout';
+import babelProcessor from '../babel-processor';
 
-module.exports = comparestdout(execute(babelProcessor(filecheck(exercise))));
+var obj = comparestdout(execute(babelProcessor(filecheck(exercise()))));
 
-module.exports.addSetup(function(mode, cb) {
+obj.addSetup(function(mode, cb) {
   if (process.argv.length !== 5) {
     console.error("USAGE: tower-of-babel run|verify <executeFile> <importFile>");
     throw new Error("invalid arguments");
   }
   this.submissionImportFile = process.argv[4];
   this.requireImportString = ['export'];
-  var x = Math.floor(Math.random() * 100); 
-  var y = Math.floor(Math.random() * 100); 
+  var x = Math.floor(Math.random() * 100);
+  var y = Math.floor(Math.random() * 100);
   this.requiredString = ['import'];
   this.submissionArgs = this.solutionArgs = [x, y];
   process.nextTick(cb);
 });
+
+export default obj;

--- a/exercises/rest_and_spread/exercise.js
+++ b/exercises/rest_and_spread/exercise.js
@@ -1,20 +1,22 @@
 "use strict";
 
-var exercise = require('workshopper-exercise')();
-var filecheck = require('workshopper-exercise/filecheck');
-var execute = require('workshopper-exercise/execute');
-var comparestdout = require('workshopper-exercise/comparestdout');
-var babelProcessor = require('../babel-processor');
+import exercise       from 'workshopper-exercise';
+import filecheck      from 'workshopper-exercise/filecheck';
+import execute        from 'workshopper-exercise/execute';
+import comparestdout  from 'workshopper-exercise/comparestdout';
+import babelProcessor from '../babel-processor';
 
-module.exports = comparestdout(execute(babelProcessor(filecheck(exercise))));
+var obj = comparestdout(execute(babelProcessor(filecheck(exercise()))));
 
-module.exports.addSetup(function(mode, cb) {
+obj.addSetup(function(mode, cb) {
   var args = "";
   for (var i = 0; i < 100; i++) {
-    args += Math.floor(Math.random() * 100) + ","; 
+    args += Math.floor(Math.random() * 100) + ",";
   }
   args = args.substring(0, args.length - 1);
   this.requiredString = ['...'];
   this.submissionArgs = this.solutionArgs = [args];
   process.nextTick(cb);
 });
+
+export default obj;

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "workshopper"
   ],
   "dependencies": {
+    "babel": "^5.8.23",
     "babel-core": "5.6.20",
     "babel-runtime": "5.6.20",
     "q": "^1.2.0",

--- a/tower-of-babel.js
+++ b/tower-of-babel.js
@@ -1,7 +1,7 @@
-#!/usr/bin/env node
+#!/usr/bin/env babel-node
 
-const workshopper = require('workshopper-adventure');
-const path        = require('path');
+import workshopper from 'workshopper-adventure';
+import path from 'path';
 
 function fpath (f) {
   return path.join(__dirname, f)


### PR DESCRIPTION
This PR modifies `tower-of-babel` modules to use the ES6 module system. The only relevant hurdle was the use of a named import for `babel-core`, as it doesn't use `export default`.

In `babel-processor.js`:

```js
var babel = require("babel-core");
//...
var transpile = q.fbind(function (contents, filename) {
    var transpiled = babel.transform(contents, {
```

Becomes:

```js
import {transform} from "babel-core";
//...
var transpile = q.fbind(function (contents, filename) {
    var transpiled = transform(contents, {
```

