### PR TITLE
correct answer is not 'let' but 'var'

### DIFF
--- a/exercises/block_scope/solution/solution.js
+++ b/exercises/block_scope/solution/solution.js
@@ -1,5 +1,5 @@
 'use strict';
-let a = 5;
+var a = 5;
 const b = process.argv[2];
 
 if (a === 5) {


### PR DESCRIPTION
In Japanese,

```javascript
// 変数 a はblockスコープの中でも外でも再代入可能な有効な変数です。変数宣言の方法(var|let|const)のいずれを利用するべきか検討してください
var|let|const a = 5;
```

So, I think that the correct answer is `var a = 5`, but printed correct answer is `let a = 5`.