### PR TITLE
use babel-cli instead of babel

### DIFF
--- a/exercises/babel_setup/problem.es.md
+++ b/exercises/babel_setup/problem.es.md
@@ -7,7 +7,7 @@ A pesar de la potencia de la última versión de node.js, todavía no podemos us
 Para poder hacerlo, necesitamos instalar un paquete adicional llamado `babel` haciendo lo siguiente:
 
 ```shell
-$ npm install babel -g
+$ npm install babel-cli -g
 ```
 
 Ona vez instalado, tendrás disponibles dos nuevos comandos: `babel` y `babel-node`.

--- a/exercises/babel_setup/problem.fr.md
+++ b/exercises/babel_setup/problem.fr.md
@@ -7,7 +7,7 @@ Même en utilisant la puissance de la toute dernière version de node.js, il n'e
 Pour utiliser cette nouvelle grammaire, il existe un package additionnel appelé `babel` que vous pouvez installer de la manière suivante :
 
 ```shell
-$ npm install babel -g
+$ npm install babel-cli -g
 ```
 
 Une fois ceci fait, deux nouvelles commandes deviennent accessibles : `babel` et `babel-node`.

--- a/exercises/babel_setup/problem.it.md
+++ b/exercises/babel_setup/problem.it.md
@@ -7,7 +7,7 @@ Anche con la potenza dell'ultima versione di node.js, non è possibile usare al 
 Per abilitare la nuova sintassi esiste un pacchetto aggiuntivo chiamato `babel` che puoi installare usando npm:
 
 ```shell
-$ npm install babel -g
+$ npm install babel-cli -g
 ```
 
 Una volta completato questo passo, saranno disponibili due nuovi comandi: `babel` e `babel-node`.

--- a/exercises/babel_setup/problem.ja.md
+++ b/exercises/babel_setup/problem.ja.md
@@ -4,7 +4,7 @@ ES6の構文は現時点では node.js を使っても全ての機能は使え�
 そこで、一旦 ES6 の文法を有効にするために、 `babel` をインストールします。
 
 ```shell
-$ npm install babel -g
+$ npm install babel-cli -g
 ```
 
 こうすると、 `babel` と `babel-node` の２つのコマンドが有効になります。

--- a/exercises/babel_setup/problem.ko.md
+++ b/exercises/babel_setup/problem.ko.md
@@ -4,7 +4,7 @@ ES6의 구문은 현시점에서 node.js를 사용해도 모든 기능을 사용
 여기에, 일단 ES6의 문법을 사용하기 위해, `babel` 바벨을 설치합니다.
 
 ```shell
-$ npm install babel -g
+$ npm install babel-cli -g
 ```
 
 이렇게 하면, `babel`과 `babel-node`의 두 개의 커맨드를 사용할 수 있습니다.

--- a/exercises/babel_setup/problem.md
+++ b/exercises/babel_setup/problem.md
@@ -7,7 +7,7 @@ Even with the power of the latest version of node.js, it isn't possible right no
 To enable a lot of the new grammar, there is an additional package called `babel` which you can install using:
 
 ```shell
-$ npm install babel -g
+$ npm install babel-cli -g
 ```
 
 Once you have done that, two new commands become available: `babel` and `babel-node`.


### PR DESCRIPTION
Update to readme to use babel-cli instead of babel because the CLI has been moved into the package `babel-cli`